### PR TITLE
Changed Queue to Manager.Queue() and added necessary imports

### DIFF
--- a/xboxClass.py
+++ b/xboxClass.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python
 import evdev
 import serial
+
+from multiprocessing import Manager
+from mulitprocessing import Queue
+
 from ControllerBaseClass import ControllerBaseClass
 
 class XBOXController(ControllerBaseClass):
@@ -38,7 +42,8 @@ class XBOXController(ControllerBaseClass):
 
     controllerData = 0
 
-    dataQueue = Queue(maxsize = QUEUESIZE)
+    manager = Manager()
+    dataQueue = manager.Queue(maxsize = QUEUESIZE)
 
     def __init__(self, arg):
 	super(XBOXController, self).__init__()


### PR DESCRIPTION
Check my commit log for this branch. It needs to be a Manager.Queue() for it to play well with multiprocessing. Eventually that queue is going to have to be shared with the interpreter. 